### PR TITLE
bootstrap: allow autotools from anywhere

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -6,12 +6,10 @@ set -x
 rm -rf admin
 mkdir admin
 
-if [ -e /usr/bin/glibtoolize ] ; then
-    glibtoolize --force
-elif [ -e /usr/bin/libtoolize ] ; then
-    libtoolize --force
-elif [ -e /usr/local/bin/libtoolize ] ; then
-    libtoolize --force
+if glibtoolize --version >/dev/null; then
+    LIBTOOLIZE=glibtoolize
+elif libtoolize --version >/dev/null; then
+    LIBTOOLIZE=libtoolize
 else
    echo "ERROR: I cannot find libtoolize or glibtoolize!"
    exit 1
@@ -27,27 +25,13 @@ else
    exit 1
 fi
 
-if [ -e /usr/bin/aclocal ] ; then
-   /usr/bin/aclocal -I $ACLOCALDIR
-elif [ -e /usr/local/bin/aclocal ] ; then
-   /usr/local/bin/aclocal -I $ACLOCALDIR
-elif [ -e /usr/bin/aclocal-1.10 ] ; then
-   /usr/bin/aclocal-1.10 -I $ACLOCALDIR
-else
-   echo >&2 "ERROR: No aclocal installation found!"
-   exit 1
-fi
+ACLOCAL=${ACLOCAL:-aclocal}
+AUTOHEADER=${AUTOHEADER:-autoheader}
+AUTOMAKE=${AUTOMAKE:-automake}
+AUTOCONF=${AUTOCONF:-autoconf}
 
-autoheader
-if [ -e /usr/bin/automake ] ; then
-   /usr/bin/automake --gnu --add-missing --copy
-elif [ -e /usr/local/bin/automake ] ; then
-   /usr/local/bin/automake --gnu --add-missing --copy
-elif [ -e /usr/bin/automake-1.10 ] ; then
-   /usr/bin/automake-1.10 --gnu --add-missing --copy
-else
-   echo >&2 "ERROR: No automake installation found!"
-   exit 1
-fi
-autoconf
-
+"$LIBTOOLIZE" --force
+"$ACLOCAL" -I "$ACLOCALDIR"
+"$AUTOHEADER"
+"$AUTOMAKE" --gnu --add-missing --copy
+"$AUTOCONF"


### PR DESCRIPTION
The current script didn't work for users of [Homebrew](http://brew.sh) who will have `glibtoolize` installed into `/usr/local/bin` or somewhere other than `usr/bin`
