### PR TITLE
Format IPv4-embedded IPv6 addresses

### DIFF
--- a/src/subnetcalc.cc
+++ b/src/subnetcalc.cc
@@ -591,6 +591,9 @@ void printAddressProperties(std::ostream&         os,
       else if(IN6_IS_ADDR_V4MAPPED(&ipv6address)) {
          os << "   - IPv4-mapped IPv6 address" << std::endl;
       }
+      else if(hasTranslationPrefix(&address.in6)) {
+         os << "   - IPv4-embedded IPv6 address" << std::endl;
+      }
 
       // ------ Multicast addresses -----------------------------------------
       else if(IN6_IS_ADDR_MULTICAST(&ipv6address)) {

--- a/src/test1
+++ b/src/test1
@@ -19,3 +19,6 @@ $TEST ./subnetcalc fd01:1122:3344:affe:0102:03ff:fe04:0506 64 -uniquelocal
 
 $TEST ./subnetcalc ff02::1:ff11:2233 104
 $TEST ./subnetcalc ff3e:0::123:4 128
+
+$TEST ./subnetcalc -n 64:ff9b::1.2.3.4 96
+$TEST ./subnetcalc -n 64:ff9b:1:2:3:4:5.6.7.8 96

--- a/src/tools.h
+++ b/src/tools.h
@@ -55,6 +55,7 @@ union sockaddr_union {
 };
 
 bool checkIPv6();
+bool hasTranslationPrefix(const sockaddr_in6* address);
 size_t getSocklen(const struct sockaddr* address);
 bool address2string(const struct sockaddr* address,
                     char*                  buffer,


### PR DESCRIPTION
IPv4-embedded IPv6 addresses (as defined in RFC 6052 and RFC 8215) are
currently formatted as regular IPv6 addresses. Format these addresses in the
same way as IPv4-compatible or IPv4-mapped IPv6 addresses to make them easier to read.

Formatting is only done when the Well-Known Prefix (64:ff9b::/96) or the local use
translation prefix (64:ff9b:1::/48) is used.